### PR TITLE
silent option

### DIFF
--- a/read-installed.js
+++ b/read-installed.js
@@ -118,11 +118,11 @@ function readInstalled (/* folder, depth, silent, cb */) {
   var args   = [].slice.call(arguments),
       cb     = args.pop(),
       folder = args.shift(),
-      depth  = args.shift(),
+      depth  = args.shift() || Infinity,
       silent = args.pop();
 
   if (typeof depth === "boolean") silent = depth, depth = Infinity
-  
+
   // silent logs
   if(silent) disableLogging()
     


### PR DESCRIPTION
if you call the function like

``` javascript
readInstalled(path, boolean, cb);
```

and boolean is true npmlog will be silenced even though it's available
