### PR TITLE
npm --depth option edge case fix

### DIFF
--- a/read-installed.js
+++ b/read-installed.js
@@ -206,7 +206,14 @@ function readInstalled_ (folder, parent, name, reqver, depth, maxDepth, cb) {
         return readJson(jsonFile, function (er, depData) {
           // already out of our depth, ignore errors
           if (er || !depData || !depData.version) return cb(null, obj)
-          obj.dependencies[pkg] = depData.version
+          if (depth === maxDepth) {
+            // edge case, ignore dependencies
+            depData.dependencies = {}
+            depData.peerDependencies = {}
+            obj.dependencies[pkg] = depData
+          } else {
+            obj.dependencies[pkg] = depData.version
+          }
           cb(null, obj)
         })
       }


### PR DESCRIPTION
When a dependency has depth === maxDepth, it should be set with its
package info instead of a plain version string (treated as a problem
by npm). It should also have its own dependencies/peerDependencies
set to an empty object to prevent them being output in `npm ls`.

This is part of the patch to fix `npm ls` with a `--depth=x` option.
See https://github.com/isaacs/npm/pull/4179
