### PR TITLE
Fix the detection of invalid version

### DIFF
--- a/read-installed.js
+++ b/read-installed.js
@@ -177,7 +177,7 @@ function readInstalled_ (folder, parent, name, reqver, depth, maxDepth, cb) {
     obj.realName = name || obj.name
     obj.dependencies = obj.dependencies || {}
 
-    // "foo":"http://blah" is always presumed valid
+    // "foo":"http://blah" and "foo":"latest" are always presumed valid
     if (reqver
         && semver.validRange(reqver, true)
         && !semver.satisfies(obj.version, reqver, true)) {
@@ -285,9 +285,9 @@ function findUnmet (obj, log) {
           r = r.link ? null : r.parent
           continue
         }
+        // "foo":"http://blah" and "foo":"latest" are always presumed valid
         if ( typeof deps[d] === "string"
-            // url deps presumed innocent.
-            && !url.parse(deps[d]).protocol
+            && semver.validRange(deps[d], true)
             && !semver.satisfies(found.version, deps[d], true)) {
           // the bad thing will happen
           log("unmet dependency", obj.path + " requires "+d+"@'"+deps[d]

--- a/test/fixtures/peer-at-latest/node_modules/debug/package.json
+++ b/test/fixtures/peer-at-latest/node_modules/debug/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "debug",
+  "version": "0.7.4",
+  "dependencies": {},
+  "_id": "debug@0.7.4",
+  "_from": "debug@latest"
+}

--- a/test/fixtures/peer-at-latest/node_modules/strong-task-emitter/package.json
+++ b/test/fixtures/peer-at-latest/node_modules/strong-task-emitter/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "strong-task-emitter",
+  "version": "0.0.4",
+  "dependencies": {
+    "debug": "latest"
+  },
+  "_id": "strong-task-emitter@0.0.4",
+  "_from": "strong-task-emitter@0.0.4",
+  "_resolved": "https://registry.npmjs.org/strong-task-emitter/-/strong-task-emitter-0.0.4.tgz"
+}

--- a/test/peer-dep-at-latest.js
+++ b/test/peer-dep-at-latest.js
@@ -1,0 +1,14 @@
+var readInstalled = require('../read-installed.js')
+var test = require('tap').test
+var path = require('path');
+
+test('"latest" version is valid', function(t) {
+  // This test verifies npm#3860
+  readInstalled(
+    path.join(__dirname, 'fixtures/peer-at-latest'),
+    console.error,
+    function(err, map) {
+      t.notOk(map.dependencies.debug.invalid, 'debug@latest is satisfied by a peer')
+      t.end()
+    })
+})


### PR DESCRIPTION
Modify the condition checking whether a dependency version satisfies the range required in package.json, so that 'latest' is always considered as valid.

Fixes npm/npm#3860.
