### PR TITLE
allow peer dependencies to be satisfied by grandparent

### DIFF
--- a/read-installed.js
+++ b/read-installed.js
@@ -331,7 +331,11 @@ function findUnmet (obj, opts) {
         obj.dependencies[d] = peerDeps[d]
       }
     } else {
-      dependency = obj.parent.dependencies && obj.parent.dependencies[d]
+      var r = obj.parent
+      while (r && !dependency) {
+        dependency = r.dependencies && r.dependencies[d]
+        r = r.link ? null : r.parent
+      }
     }
 
     if (!dependency) {

--- a/test/fixtures/grandparent-peer/node_modules/framework/package.json
+++ b/test/fixtures/grandparent-peer/node_modules/framework/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "framework",
+  "version": "0.0.0"
+}

--- a/test/fixtures/grandparent-peer/node_modules/plugin-wrapper/node_modules/plugin/package.json
+++ b/test/fixtures/grandparent-peer/node_modules/plugin-wrapper/node_modules/plugin/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "plugin",
+  "version": "0.0.0",
+  "peerDependencies": {
+    "framework": "0.0.0"
+  }
+}

--- a/test/fixtures/grandparent-peer/node_modules/plugin-wrapper/package.json
+++ b/test/fixtures/grandparent-peer/node_modules/plugin-wrapper/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "plugin-wrapper",
+  "version": "0.0.0",
+  "dependencies": {
+    "plugin": "0.0.0"
+  }
+}

--- a/test/fixtures/grandparent-peer/package.json
+++ b/test/fixtures/grandparent-peer/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "example",
+  "version": "0.0.0",
+  "dependencies": {
+    "plugin-wrapper": "0.0.0",
+    "framework": "0.0.0"
+  }
+}

--- a/test/grandparent-peer.js
+++ b/test/grandparent-peer.js
@@ -1,0 +1,24 @@
+var readInstalled = require('../read-installed.js')
+var test = require('tap').test
+var path = require('path');
+
+function allValid(t, map) {
+  var deps = Object.keys(map.dependencies || {})
+  deps.forEach(function (dep) {
+    t.notOk(map.dependencies[dep].invalid, 'dependency ' + dep + ' of ' + map.name + ' is not invalid')
+    t.notOk(typeof map.dependencies[dep] === 'string', 'dependency ' + dep + ' of ' + map.name + ' is not missing')
+  })
+  deps.forEach(function (dep) {
+    allValid(t, map.dependencies[dep])
+  })
+}
+
+test('grandparent can satisfy peer dependencies', function(t) {
+  readInstalled(
+    path.join(__dirname, 'fixtures/grandparent-peer'),
+    { log: console.error },
+    function(err, map) {
+      allValid(t, map)
+      t.end()
+    })
+})


### PR DESCRIPTION
this matches the behavior of `npm install` when the dependency graph is more than one level deep.

currently, a `npm ls` immediately after a `npm install` will complain (`plugin` peer-depends on `framework`):

<pre>example@0.0.0
├── framework@0.0.0
└─┬ plugin-wrapper@0.0.0
  └─┬ plugin@0.0.0
    └── UNMET DEPENDENCY framework 0.0.0</pre>
