### PR TITLE
Fixes peerDependencies being allowed even if they are devDeps

### DIFF
--- a/read-installed.js
+++ b/read-installed.js
@@ -330,7 +330,7 @@ function findUnmet (obj, opts) {
     } else if (!semver.satisfies(dependency.version, peerDeps[d], true)) {
       dependency.peerInvalid = true
     } else {
-      dependency.extraneous = false
+      dependency.extraneous = dependency.extraneous || false
     }
   })
 

--- a/test/fixtures/grandparent-peer-dev/package.json
+++ b/test/fixtures/grandparent-peer-dev/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "example",
+  "version": "0.0.0",
+  "devDependencies": {
+    "plugin-wrapper": "0.0.0",
+    "framework": "0.0.0"
+  }
+}

--- a/test/grandparent-peer-dev.js
+++ b/test/grandparent-peer-dev.js
@@ -1,0 +1,20 @@
+var readInstalled = require('../read-installed.js')
+var test = require('tap').test
+var path = require('path');
+
+function allValid(t, map) {
+  var deps = Object.keys(map.dependencies || {})
+  deps.forEach(function (dep) {
+    t.ok(map.dependencies[dep].extraneous, 'dependency ' + dep + ' of ' + map.name + ' is extraneous')
+  })
+}
+
+test('grandparent dev peer dependencies should be extraneous', function(t) {
+  readInstalled(
+    path.join(__dirname, 'fixtures/grandparent-peer-dev'),
+    { log: console.error },
+    function(err, map) {
+      allValid(t, map)
+      t.end()
+    })
+})


### PR DESCRIPTION
If a devDep is a peerDependency then it should be marked as extraneous if `dev` is set to `false`.

This fixes npm/npm#5586
