### PR TITLE
Ignore devDependencies when the dev option === false

### DIFF
--- a/read-installed.js
+++ b/read-installed.js
@@ -222,7 +222,7 @@ function readInstalled_ (folder, parent, name, reqver, depth, opts, cb) {
       var rv = obj.dependencies[pkg]
       if (!rv && obj.devDependencies && opts.dev)
         rv = obj.devDependencies[pkg]
-      else if (!rv && opts.dev === false)
+      else if (!rv)
         return cb(null, obj)
 
       if (depth > opts.depth) {


### PR DESCRIPTION
This makes it impossible for npm rebuild to only gather the non-devDependencies

fixes #30

ref https://github.com/npm/npm/issues/5952
