### PR TITLE
Add failing test and fix error in empty or bad path

### DIFF
--- a/read-installed.js
+++ b/read-installed.js
@@ -359,7 +359,7 @@ function unmarkExtraneous (obj, opts) {
   }
 
   debug("not extraneous", obj._id, deps)
-  Object.keys(deps).forEach(function (d) {
+  Object.keys(deps || []).forEach(function (d) {
     var dep = findDep(obj, d)
     if (dep && dep.extraneous) {
       unmarkExtraneous(dep, opts)

--- a/test/empty.js
+++ b/test/empty.js
@@ -1,0 +1,16 @@
+var readInstalled = require("../read-installed.js");
+var test = require("tap").test;
+var path = require("path");
+
+test("Handle bad path", function (t) {
+  readInstalled(path.join(__dirname, "../unknown"), {
+    dev: true,
+    log: console.error
+  }, function (er, map) {
+      t.notOk(er, "er should be null");
+      t.ok(map, "map should be data");
+      t.equal(Object.keys(map.dependencies).length, 0, "Dependencies should have no keys");
+      if (er) return console.error(er.stack || er.message);
+      t.end();
+  });
+});


### PR DESCRIPTION
- When applying on bad or empty path read-installed throw an error about Object.keys
- This commits adds a failing test
- Fixed error
