### PR TITLE
Fix issue #40.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-before_script: npm install -g npm@latest
+before_install:
+  - '[ "${TRAVIS_NODE_VERSION}" != "0.8" ] || npm install -g npm@1.4.28'
+  - npm install -g npm@latest
 node_js:
   - '0.8'
   - '0.10'

--- a/read-installed.js
+++ b/read-installed.js
@@ -56,7 +56,7 @@ to READ(packagefolder, parentobj, name, reqver)
 obj = read package.json
 installed = ./node_modules/*
 if parentobj is null, and no package.json
-  obj = {dependencies:{<installed>:"*"}}
+  obj = {dependencies:{<installed>:ANY}}
 deps = Object.keys(obj.dependencies)
 obj.path = packagefolder
 obj.parent = parentobj
@@ -104,6 +104,10 @@ var extend = require("util-extend")
 var debug = require("debuglog")("read-installed")
 
 var readdir = require("readdir-scoped-modules")
+
+// Sentinel catch-all version constraint used when a dependency is not
+// listed in the package.json file.
+var ANY = {}
 
 module.exports = readInstalled
 
@@ -190,7 +194,7 @@ function readInstalled_ (folder, parent, name, reqver, depth, opts, cb) {
     if (realpathSeen[real]) return cb(null, realpathSeen[real])
     if (obj === true) {
       obj = {dependencies:{}, path:folder}
-      installed.forEach(function (i) { obj.dependencies[i] = "*" })
+      installed.forEach(function (i) { obj.dependencies[i] = ANY })
     }
     if (name && obj.name !== name) obj.invalid = true
     obj.realName = name || obj.name
@@ -199,10 +203,17 @@ function readInstalled_ (folder, parent, name, reqver, depth, opts, cb) {
     // At this point, figure out what dependencies we NEED to get met
     obj._dependencies = copy(obj.dependencies)
 
+    if (reqver === ANY) {
+      // We were unable to determine the required version of this
+      // dependency from the package.json file, but we now know its actual
+      // version, so treat that version as the required version to avoid
+      // marking the dependency as invalid below. See #40.
+      reqver = obj.version;
+    }
+
     // "foo":"http://blah" and "foo":"latest" are always presumed valid
     if (reqver
         && semver.validRange(reqver, true)
-        && reqver !== "*" // See #40.
         && !semver.satisfies(obj.version, reqver, true)) {
       obj.invalid = true
     }

--- a/read-installed.js
+++ b/read-installed.js
@@ -202,6 +202,7 @@ function readInstalled_ (folder, parent, name, reqver, depth, opts, cb) {
     // "foo":"http://blah" and "foo":"latest" are always presumed valid
     if (reqver
         && semver.validRange(reqver, true)
+        && reqver !== "*" // See #40.
         && !semver.satisfies(obj.version, reqver, true)) {
       obj.invalid = true
     }

--- a/test/fixtures/issue-40/node_modules/fake/package.json
+++ b/test/fixtures/issue-40/node_modules/fake/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fake",
+  "version": "0.1.0-2",
+  "description": "A fake package with a prerelease version. See #40."
+}

--- a/test/issue-40.js
+++ b/test/issue-40.js
@@ -1,0 +1,15 @@
+var readInstalled = require('../read-installed.js');
+var test = require('tap').test;
+var path = require('path');
+
+test('prerelease packages should not be marked invalid', function(t) {
+  readInstalled(
+    path.join(__dirname, 'fixtures/issue-40'),
+    { log: console.error },
+    function(err, map) {
+      t.strictEqual(map.dependencies.fake.version, '0.1.0-2');
+      t.notOk(map.dependencies.fake.invalid);
+      t.end();
+    }
+  );
+});


### PR DESCRIPTION
The https://github.com/npm/node-semver package recently introduced [a subtle breaking change](https://github.com/npm/node-semver/commit/93a870665bba0f4be5c4edc19d6f94ff39ad60e8) that led to issue #40.

This PR works around that problem by avoiding the `*` version constraint in favor of an unambiguous sentinel object.

This PR could be construed as a breaking change for https://github.com/npm/read-installed, since the output format will be slightly different (`{}` instead of `"*"` in some cases), but I believe that's (1) a very minor disruption, and (2) a disruption worth addressing, if it causes any problems.