### PR TITLE
deps: Upgrade graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "util-extend": "^1.0.1"
   },
   "optionalDependencies": {
-    "graceful-fs": "2 || 3"
+    "graceful-fs": "^4.1.2"
   },
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "license": "ISC",


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

Related: https://github.com/nodejs/node/pull/2714