### PR TITLE
chore: bump version of semver package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -633,6 +633,14 @@
         "@babel/types": "^7.0.0",
         "istanbul-lib-coverage": "^2.0.3",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "js-tokens": {
@@ -803,6 +811,13 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "nyc": {
@@ -2024,9 +2039,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "debuglog": "^1.0.1",
     "read-package-json": "^2.0.0",
     "readdir-scoped-modules": "^1.0.0",
-    "semver": "2 || 3 || 4 || 5",
+    "semver": "^6.3.0",
     "slide": "~1.1.3",
     "util-extend": "^1.0.1"
   },


### PR DESCRIPTION
Updating the `semver` dependency.

Todos:
- [ ] bump minor version (& tag)
- [ ] publish package

Linked Issues:
- npm/node-semver#289